### PR TITLE
Update super-linter.yml to use specific versions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,12 +16,13 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v8
+        uses: super-linter/super-linter/slim@v8.0.0
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: .*css/.*


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for linting to use fixed, fully-pinned versions of actions for improved security and reproducibility.

Workflow dependency pinning:

* [`.github/workflows/super-linter.yml`](diffhunk://#diff-3336387af05d3a6efeaa358d145494d23b6036f9034efe8ff6edca2522f06c33L19-R25): Pins `actions/checkout` to a specific commit hash and sets `persist-credentials: false` for enhanced security.
* [`.github/workflows/super-linter.yml`](diffhunk://#diff-3336387af05d3a6efeaa358d145494d23b6036f9034efe8ff6edca2522f06c33L19-R25): Pins `super-linter/super-linter/slim` to the full `v8.0.0` version for more predictable builds.