### PR TITLE
Update Dependabot schedule and PR limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,12 @@ updates:
     schedule:
       interval: monthly
     versioning-strategy: increase
+    open-pull-requests-limit: 2
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to better control automated dependency updates and group related pull requests. The main changes involve limiting the number of open pull requests and grouping updates for GitHub Actions.

Dependabot configuration improvements:

* Added `open-pull-requests-limit: 2` to restrict the number of simultaneous open pull requests for dependency updates.
* Changed the update interval for GitHub Actions from weekly to monthly to reduce update frequency.
* Introduced a `groups` section to group all GitHub Actions updates under the `github-actions` group, matching all patterns.